### PR TITLE
Add buildvcs=false to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ ADD . /app
 
 WORKDIR /app
 
-RUN go build -o main .
+RUN go build -buildvcs=false -o main .
 
 CMD ["/app/main"]


### PR DESCRIPTION
Otherwise go build fails with error (probably due to the detached HEAD revision)